### PR TITLE
docs: fix link to Helm charts docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ TODO(jzelinskie): write this section
 Examples of DAC formats include:
 
 * [Kubernetes Object Files](https://kubernetes.io/docs/concepts/abstractions/overview/)
-* [Helm Charts](https://github.com/kubernetes/helm/blob/master/docs/charts.md)
+* [Helm Charts](https://helm.sh/docs/topics/charts/)
 * [KPM Packages](https://github.com/coreos/kpm/blob/master/Documentation/create_packages.md)
 * [Docker Compose Files](https://docs.docker.com/compose/)
 * [Docker Distributed Application Bundles](https://docs.docker.com/compose/bundles/)


### PR DESCRIPTION
Project README referenced `docs/charts.md` in the Helm source code repository.  This file no longer exists (last commit in git history is [2e87126](https://github.com/helm/helm/blob/2e871267def61b89feece273beb47ad6bb50b9b4/docs/charts.md) on 2019-09-30).

Link instead to the "Charts" topic in the documentation section of the Helm project website.